### PR TITLE
Unrelated to "Religion".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,8 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
 
-        'Intended Audience :: Religion',
-        'Topic :: Religion',
-
+        'Intended Audience :: Other Audience',
+        
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Seems to be set to "Religion" as a joke, but this is polluting the PyPi name spaces. Cleaning up.

Note: Untested,